### PR TITLE
load the dynamic manifest if possible

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -1,0 +1,47 @@
+module.exports = {
+  // users
+  auth: 'async',
+  whoami: 'async',
+  getPublicKey: 'async',
+
+  // messages
+  get: 'async',
+  getLatest: 'async',
+  add: 'async',
+
+  // indexes
+  createFeedStream: 'source',
+  createHistoryStream: 'source',
+  createLogStream: 'source',
+  messagesByType: 'source',
+  messagesLinkedToMessage: 'source',
+  messagesLinkedToFeed: 'source',
+  messagesLinkedFromFeed: 'source',
+  feedsLinkedToFeed: 'source',
+  feedsLinkedFromFeed: 'source',
+  followedUsers: 'source',
+  relatedMessages: 'async',
+
+  // network
+  getLocal: 'async',
+
+  // plugins
+  invite: {
+    addMe: 'async'
+  },
+  gossip: {
+    peers: 'sync',
+    connect: 'async'
+  },
+  friends: {
+    all: 'sync',
+    hops: 'sync'
+  },
+  blobs: {
+    get: 'source',
+    has: 'async',
+    add: 'sink',
+    ls: 'source',
+    want: 'async'
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,47 +1,5 @@
-module.exports = {
-  // users
-  auth: 'async',
-  whoami: 'async',
-  getPublicKey: 'async',
 
-  // messages
-  get: 'async',
-  getLatest: 'async',
-  add: 'async',
+module.exports = require('./load')(require('ssb-config'))
 
-  // indexes
-  createFeedStream: 'source',
-  createHistoryStream: 'source',
-  createLogStream: 'source',
-  messagesByType: 'source',
-  messagesLinkedToMessage: 'source',
-  messagesLinkedToFeed: 'source',
-  messagesLinkedFromFeed: 'source',
-  feedsLinkedToFeed: 'source',
-  feedsLinkedFromFeed: 'source',
-  followedUsers: 'source',
-  relatedMessages: 'async',
-
-  // network
-  getLocal: 'async',
-
-  // plugins
-  invite: {
-    addMe: 'async'
-  },
-  gossip: {
-    peers: 'sync',
-    connect: 'async'
-  },
-  friends: {
-    all: 'sync',
-    hops: 'sync'
-  },
-  blobs: {
-    get: 'source',
-    has: 'async',
-    add: 'sink',
-    ls: 'source',
-    want: 'async'
-  }
-}
+if(!module.parent && process.title !== 'browser')
+  console.log(module.exports)

--- a/load.js
+++ b/load.js
@@ -1,0 +1,22 @@
+var path = require('path')
+var readFileSync = require('fs').readFileSync
+
+module.exports = function (config) {
+
+  if(process.title === 'browser' && window.SSB_MANIFEST)
+    return SSB_MANIFEST
+
+  //if we are on the client
+  if(readFileSync && config && config.path)
+    var filename = path.join(config.path, 'manifest.json')
+    try {
+      return JSON.parse(
+        readFileSync(filename, 'utf-8')
+      )
+    } catch (err) {
+      console.error('could not parse:'+filename)
+      console.error(err.stack)
+    }
+
+  return require('./defaults')
+}

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "bugs": {
     "url": "https://github.com/ssbc/ssb-manifest/issues"
   },
-  "homepage": "https://github.com/ssbc/ssb-manifest"
+  "homepage": "https://github.com/ssbc/ssb-manifest",
+  "dependencies": {
+    "ssb-config": "~1.0.0"
+  }
 }


### PR DESCRIPTION
This loads the manifest from the configured manifest file, or from the defaults as before.
The api has not changed. `require('ssb-manifest')` still returns the manifest,
but if you use `require('ssb-manifest/load`)` to get a function to load the manifest you can pass your own config to.
